### PR TITLE
More robust test scripts, GIF maker script, robust & reproducible python environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required (VERSION 3.9)
 
+# Use new policies on versions of CMake that have been tested
+cmake_policy(VERSION 3.9.3...3.15.4)
+
+# Let us use, e.g., PNG_ROOT=/path/to/libpng, in the environment to
+# tell find_package() where to look. Usefull on clusters.
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
+
 project (rescal-snow
   DESCRIPTION "Simulating snow self-organization with cellular automata"
   LANGUAGES C

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+numpy = "*"
+matplotlib = "*"
+scipy = "*"
+pandas = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,169 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b6daa6111a714911c68f098c7f8626a9b0182c7ff61e2e53c849e74c6c419758"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:05b5b061e09f60f56244adc885c4a7867da25ca387376b02c1efc29cc16bcd0f",
+                "sha256:26f4fbd6f5e1dabff70a9ba0d2c4bd30761086454aa30dddc5b52764ee4852b7",
+                "sha256:3b2378ad387f49cbb328205bda569b9f87288d6bc1bf4cd683c34523a2341efe",
+                "sha256:400599c0fe58d21522cae0e8b22318e09d9729451b17ee61ba8e1e7c0346565c",
+                "sha256:47b8cb81a7d18dbaf4fed6a61c3cecdb5adec7b4ac292bddb0d016d57e8507d5",
+                "sha256:53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75",
+                "sha256:58e626e1f7dfbb620d08d457325a4cdac65d1809680009f46bf41eaf74ad0187",
+                "sha256:5a52e1b006bfa5be04fe4debbcdd2688432a9af4b207a3f429c74ad625022641",
+                "sha256:5c7ca4e449ac9f99b3b9d4693debb1d6d237d1542dd6a56b3305fe8a9620f883",
+                "sha256:682e54f0ce8f45981878756d7203fd01e188cc6c8b2c5e2cf03675390b4534d5",
+                "sha256:79bfb2f0bd7cbf9ea256612c9523367e5ec51d7cd616ae20ca2c90f575d839a2",
+                "sha256:7f4dd50874177d2bb060d74769210f3bce1af87a8c7cf5b37d032ebf94f0aca3",
+                "sha256:8944a16020c07b682df861207b7e0efcd2f46c7488619cb55f65882279119389",
+                "sha256:8aa7009437640beb2768bfd06da049bad0df85f47ff18426261acecd1cf00897",
+                "sha256:939f36f21a8c571686eb491acfffa9c7f1ac345087281b412d63ea39ca14ec4a",
+                "sha256:9733b7f64bd9f807832d673355f79703f81f0b3e52bfce420fc00d8cb28c6a6c",
+                "sha256:a02f6c3e229d0b7220bd74600e9351e18bc0c361b05f29adae0d10599ae0e326",
+                "sha256:a0c0a9f06872330d0dd31b45607197caab3c22777600e88031bfe66799e70bb0",
+                "sha256:acc4df99308111585121db217681f1ce0eecb48d3a828a2f9bbf9773f4937e9e",
+                "sha256:b64916959e4ae0ac78af7c3e8cef4becee0c0e9694ad477b4c6b3a536de6a544",
+                "sha256:d3fcf0819dc3fea58be1fd1ca390851bdb719a549850e708ed858503ff25d995",
+                "sha256:d52e3b1868a4e8fd18b5cb15055c76820df514e26aa84cc02f593d99fef6707f",
+                "sha256:db1a5d3cc4ae943d674718d6c47d2d82488ddd94b93b9e12d24aabdbfe48caee",
+                "sha256:e3a21a720791712ed721c7b95d433e036134de6f18c77dbe96119eaf7aa08004",
+                "sha256:e8bf074363ce2babeb4764d94f8e65efd22e6a7c74860a4f05a6947afc020ff2",
+                "sha256:f16814a4a96dc04bf1da7d53ee8d5b1d6decfc1a92a63349bb15d37b6a263dd9",
+                "sha256:f2b22153870ca5cf2ab9c940d7bc38e8e9089fa0f7e5856ea195e1cf4ff43d5a",
+                "sha256:f790f8b3dff3d53453de6a7b7ddd173d2e020fb160baff578d578065b108a05f"
+            ],
+            "version": "==1.1.0"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:1febd22afe1489b13c6749ea059d392c03261b2950d1d45c17e3aed812080c93",
+                "sha256:31a30d03f39528c79f3a592857be62a08595dec4ac034978ecd0f814fa0eec2d",
+                "sha256:4442ce720907f67a79d45de9ada47be81ce17e6c2f448b3c64765af93f6829c9",
+                "sha256:796edbd1182cbffa7e1e7a97f1e141f875a8501ba8dd834269ae3cd45a8c976f",
+                "sha256:934e6243df7165aad097572abf5b6003c77c9b6c480c3c4de6f2ef1b5fdd4ec0",
+                "sha256:bab9d848dbf1517bc58d1f486772e99919b19efef5dd8596d4b26f9f5ee08b6b",
+                "sha256:c1fe1e6cdaa53f11f088b7470c2056c0df7d80ee4858dadf6cbe433fcba4323b",
+                "sha256:e5b8aeca9276a3a988caebe9f08366ed519fff98f77c6df5b64d7603d0e42e36",
+                "sha256:ec6bd0a6a58df3628ff269978f4a4b924a0d371ad8ce1f8e2b635b99e482877a"
+            ],
+            "index": "pypi",
+            "version": "==3.1.1"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:05dbfe72684cc14b92568de1bc1f41e5f62b00f714afc9adee42f6311738091f",
+                "sha256:0d82cb7271a577529d07bbb05cb58675f2deb09772175fab96dc8de025d8ac05",
+                "sha256:10132aa1fef99adc85a905d82e8497a580f83739837d7cbd234649f2e9b9dc58",
+                "sha256:12322df2e21f033a60c80319c25011194cd2a21294cc66fee0908aeae2c27832",
+                "sha256:16f19b3aa775dddc9814e02a46b8e6ae6a54ed8cf143962b4e53f0471dbd7b16",
+                "sha256:3d0b0989dd2d066db006158de7220802899a1e5c8cf622abe2d0bd158fd01c2c",
+                "sha256:438a3f0e7b681642898fd7993d38e2bf140a2d1eafaf3e89bb626db7f50db355",
+                "sha256:5fd214f482ab53f2cea57414c5fb3e58895b17df6e6f5bca5be6a0bb6aea23bb",
+                "sha256:73615d3edc84dd7c4aeb212fa3748fb83217e00d201875a47327f55363cef2df",
+                "sha256:7bd355ad7496f4ce1d235e9814ec81ee3d28308d591c067ce92e49f745ba2c2f",
+                "sha256:7d077f2976b8f3de08a0dcf5d72083f4af5411e8fddacd662aae27baa2601196",
+                "sha256:a4092682778dc48093e8bda8d26ee8360153e2047826f95a3f5eae09f0ae3abf",
+                "sha256:b458de8624c9f6034af492372eb2fee41a8e605f03f4732f43fc099e227858b2",
+                "sha256:e70fc8ff03a961f13363c2c95ef8285e0cf6a720f8271836f852cc0fa64e97c8",
+                "sha256:ee8e9d7cad5fe6dde50ede0d2e978d81eafeaa6233fb0b8719f60214cf226578",
+                "sha256:f4a4f6aba148858a5a5d546a99280f71f5ee6ec8182a7d195af1a914195b21a2"
+            ],
+            "index": "pypi",
+            "version": "==1.17.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:18d91a9199d1dfaa01ad645f7540370ba630bdcef09daaf9edf45b4b1bca0232",
+                "sha256:3f26e5da310a0c0b83ea50da1fd397de2640b02b424aa69be7e0784228f656c9",
+                "sha256:4182e32f4456d2c64619e97c58571fa5ca0993d1e8c2d9ca44916185e1726e15",
+                "sha256:426e590e2eb0e60f765271d668a30cf38b582eaae5ec9b31229c8c3c10c5bc21",
+                "sha256:5eb934a8f0dc358f0e0cdf314072286bbac74e4c124b64371395e94644d5d919",
+                "sha256:717928808043d3ea55b9bcde636d4a52d2236c246f6df464163a66ff59980ad8",
+                "sha256:8145f97c5ed71827a6ec98ceaef35afed1377e2d19c4078f324d209ff253ecb5",
+                "sha256:8744c84c914dcc59cbbb2943b32b7664df1039d99e834e1034a3372acb89ea4d",
+                "sha256:c1ac1d9590d0c9314ebf01591bd40d4c03d710bfc84a3889e5263c97d7891dee",
+                "sha256:cb2e197b7b0687becb026b84d3c242482f20cbb29a9981e43604eb67576da9f6",
+                "sha256:d4001b71ad2c9b84ff18b182cea22b7b6cbf624216da3ea06fb7af28d1f93165",
+                "sha256:d8930772adccb2882989ab1493fa74bd87d47c8ac7417f5dd3dd834ba8c24dc9",
+                "sha256:dfbb0173ee2399bc4ed3caf2d236e5c0092f948aafd0a15fbe4a0e77ee61a958",
+                "sha256:eebfbba048f4fa8ac711b22c78516e16ff8117d05a580e7eeef6b0c2be554c18",
+                "sha256:f1b21bc5cf3dbea53d33615d1ead892dfdae9d7052fa8898083bec88be20dcd2"
+            ],
+            "index": "pypi",
+            "version": "==0.25.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+            ],
+            "version": "==2.4.2"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:0baa64bf42592032f6f6445a07144e355ca876b177f47ad8d0612901c9375bef",
+                "sha256:243b04730d7223d2b844bda9500310eecc9eda0cba9ceaf0cde1839f8287dfa8",
+                "sha256:2643cfb46d97b7797d1dbdb6f3c23fe3402904e3c90e6facfe6a9b98d808c1b5",
+                "sha256:396eb4cdad421f846a1498299474f0a3752921229388f91f60dc3eda55a00488",
+                "sha256:3ae3692616975d3c10aca6d574d6b4ff95568768d4525f76222fb60f142075b9",
+                "sha256:435d19f80b4dcf67dc090cc04fde2c5c8a70b3372e64f6a9c58c5b806abfa5a8",
+                "sha256:46a5e55850cfe02332998b3aef481d33f1efee1960fe6cfee0202c7dd6fc21ab",
+                "sha256:75b513c462e58eeca82b22fc00f0d1875a37b12913eee9d979233349fce5c8b2",
+                "sha256:7ccfa44a08226825126c4ef0027aa46a38c928a10f0a8a8483c80dd9f9a0ad44",
+                "sha256:89dd6a6d329e3f693d1204d5562dd63af0fd7a17854ced17f9cbc37d5b853c8d",
+                "sha256:a81da2fe32f4eab8b60d56ad43e44d93d392da228a77e229e59b51508a00299c",
+                "sha256:a9d606d11eb2eec7ef893eb825017fbb6eef1e1d0b98a5b7fc11446ebeb2b9b1",
+                "sha256:ac37eb652248e2d7cbbfd89619dce5ecfd27d657e714ed049d82f19b162e8d45",
+                "sha256:cbc0611699e420774e945f6a4e2830f7ca2b3ee3483fca1aa659100049487dd5",
+                "sha256:d02d813ec9958ed63b390ded463163685af6025cb2e9a226ec2c477df90c6957",
+                "sha256:dd3b52e00f93fd1c86f2d78243dfb0d02743c94dd1d34ffea10055438e63b99d"
+            ],
+            "index": "pypi",
+            "version": "==1.3.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        }
+    },
+    "develop": {}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+cycler==0.10.0
+kiwisolver==1.1.0
+matplotlib==3.1.1
+numpy==1.17.2
+pandas==0.25.1
+pyparsing==2.4.2
+python-dateutil==2.8.0
+pytz==2019.3
+scipy==1.3.1
+six==1.12.0

--- a/scripts/visualization/png_to_gif.sh
+++ b/scripts/visualization/png_to_gif.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Script to convert matplotlib pngs to animated gif
+# Arguments: gif name followed by a list of PNG images to turn into a gif
+#
+# Author: Izaak Beekman <izaak@izaakbeekman.com>
+# Date: 2019-10-14
+#
+# The author waives all rights to the source code in this script and contributes
+# it to the rescale-snow project in accordance with the projects GPLv3 license.
+# Please see LICENSE and NOTICE in the project root directory for further information.
+#
+# Obligatory CYA:
+#
+# THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+# APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+# HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT
+# WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND
+# PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE
+# DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR
+# CORRECTION.
+#
+# IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+# WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES
+# AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+# DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+# DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+# (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+# INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE
+# OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH
+# HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGES.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if (( $# < 2 )) ; then
+    echo ""
+    echo "Usage:"
+    echo "    $0 <output_name.gif> <png_img1> [<png_img2> [ ... <png_imgN>]]"
+    echo "    Requires ImageMagick to be installed."
+    echo ""
+    exit 1
+fi
+
+if ! command -v convert > /dev/null 2>&1 ; then
+    echo "You must have imagemagick's \`convert\` command installed and on your \$PATH!"
+fi
+
+OUTFILE="$1"
+shift
+
+echo "GIF will be written to $OUTFILE, from inputs:"
+printf "%s\n" "${@}"
+
+# Create a temporary directory to hold cleaned PNGs
+tmp_dir=$(mktemp -d -t rescal-images-XXXXXXXXXX)
+# echo "Temporary work directory: ${tmp_dir}"
+# ls -ld "${tmp_dir}"
+
+# Cleanup temp directory on exit or abort/user interrupt
+function cleanup {
+    rm -rf "${tmp_dir}" || true
+}
+trap cleanup EXIT
+
+# Normalize png images, & create array of cleaned up pngs
+declare -a IMG_TO_PROCESS
+for img in "$@" ; do
+    img_no_path="$(basename "$img")"
+    convert -flatten -background White "${img}" "${tmp_dir}/${img_no_path}"
+    IMG_TO_PROCESS+=("${tmp_dir}/${img_no_path}")
+done
+
+#ls "${tmp_dir}"
+
+# Create the gif from the cleaned up PNGs
+convert -delay 20 "${IMG_TO_PROCESS[@]}" -background White -loop 0 "${OUTFILE}"

--- a/test/test-rescal.sh
+++ b/test/test-rescal.sh
@@ -7,22 +7,36 @@
 # - Runs one example (scripts/snow_cone.run)
 # - Compares one output png to test data
 
-set -e          #Exit if any command fails
+set -o errexit  #Exit if any command fails
 set -o pipefail #Exit if any pipe fails
+set -o nounset  #Exit if an unset variable is de-referenced
+
+# Allow the script to be run from project root, e.g., test/test-utilities.sh or
+# from the test directory.
+test_dir="$(cd "$(dirname "$0")" && pwd)"
+
+# Find number of available cores
+if command -v ncpus > /dev/null 2>&1 ; then
+    NCPU=$(nproc --all)
+elif [[ "$OSTYPE" == "[Dd]arwin"* ]]; then
+    NCPU=$(sysctl -n hw.logicalcpu)
+else
+    NCPU=8
+fi
 
 echo "Attempting to build Rescal-snow..."
-cd ..
-rm -rf build
+cd "${test_dir%/}/.." || exit 1
+rm -rf build || true # Don't error if not present
 mkdir build
-cd build
-cmake -Wno-dev -DCMAKE_BUILD_TYPE=Release ..
-make -j 16
-cd ..
+(cd build
+cmake -Wdev -DCMAKE_BUILD_TYPE=Release ..
+make -j ${NCPU})
+
 
 # Test that Rescal-snow runs
 echo "Attempting to run Rescal-snow using the snow_cone test case..."
 echo "(This may take a few minutes)"
-cd scripts
+cd "${test_dir%/}/../scripts"
 ./snow_cone.run
 diff SNO00003_t0.png ../test/SNO00003_t0.png
 
@@ -35,9 +49,10 @@ diff SNO00003_t0.png ../test/SNO00003_t0.png
 
 # Test rescal_utilities for setting up parallel runs
 echo "Attempting rescal_utilities example..."
-cd utilities
+cd "${test_dir%/}/../scripts/utilities"
 python3 param_space_exploration_example.py
-cd ../..
+
+cd "${test_dir%/}/../"
 echo "Printing parallel directories:"
 ls test_parallel_runs
 echo "Printing directory contents:"
@@ -54,7 +69,7 @@ ls test_parallel_runs/tauMin300_lambdaI0.01
 rm -rf test_parallel_runs
 
 # Remove results of test
-cd scripts
+cd "${test_dir%/}/../scripts"
 ./clean -f
 rm -rf out
 cd ..

--- a/test/test-utilities.sh
+++ b/test/test-utilities.sh
@@ -11,20 +11,43 @@
 #    and rescal_utilities to set up some potential runs
 # Success at each stage is confirmed by the user.
 
+# Catch common scripting errors with stricter checking
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Allow the script to be run from project root, e.g., test/test-utilities.sh or
+# from the test directory.
+test_dir="$(cd "$(dirname "$0")" && pwd)"
+
+# Find number of available cores
+if command -v ncpus > /dev/null 2>&1 ; then
+    NCPU=$(nproc --all)
+elif [[ "$OSTYPE" == "[Dd]arwin"* ]]; then
+    NCPU=$(sysctl -n hw.logicalcpu)
+else
+    NCPU=8
+fi
 
 echo "Building Rescal-snow..."
-cd ..
-mkdir build
+
+# Use a subshell to automatically `cd` back to the right place
+(cd "${test_dir%/}/.." || exit 1
+mkdir build || true # Don't throw an error if the build exists
 cd build
-cmake -Wno-dev -DCMAKE_BUILD_TYPE=Release ..
-make -j 16
-cd ..
+# ensure that we're not ignoring errors caused by recent changes in CMake build files
+rm CMakeCache.txt
+# Don't silence developer warnings during testing, fix any that may be triggered
+cmake -Wdev -DCMAKE_BUILD_TYPE=Release ..
+make clean # Make sure that we're actually rebuilding everything
+make -j ${NCPU}
+)
 
 # Run snow-cone test to generate example data
 echo "Attempting to run Rescal-snow using the snow_cone test case..."
 echo "(This may take a few minutes)"
 echo "(Output not displayed - use test-rescal.sh if necessary)"
-cd scripts
+cd "${test_dir%/}/../scripts" || exit 1
 ./snow_cone.run
 
 # Test the visualization example
@@ -32,16 +55,42 @@ echo "Attempting visualization example..."
 cp ../test/viz_example_test.py .
 python3 viz_example_test.py
 rm viz_example_test.py
-eog out/*image.png
+
+# Create a gif of the PNGs if we have imagemagick
+if command -v convert >/dev/null 2>&1 ; then
+    "${test_dir%/}/../scripts/visualization/png_to_gif.sh" out/ALTI_cone.gif out/*image.png
+fi
+
+# Portably look for image viewing program, using system default application when possible
+if command -v xdg-open > /dev/null 2>&1 ; then
+    VIEWER=xdg-open
+elif command -v open > /dev/null 2>&1 ; then
+    VIEWER=open
+elif command -v eog > /dev/null 2>&1 ; then
+    VIEWER=eog
+else
+    no_viewer () {
+        printf "No known image viewer found, please manually open and inspect %s.\n" "$*"
+    }
+    VIEWER=no_viewer
+fi
+$VIEWER out/*image.png
+if [[ -f out/ALTI_cone.gif ]]; then
+    $VIEWER out/ALTI_cone.gif
+fi
 echo "(Close image to continue)"
 while true; do
-	read -p "Does the output look good? [y/n]" yn
-	case $yn in
-		[Yy]* ) echo "Good! Continuing."; break;;
-		[Nn]* ) exit;;
-		* ) echo "Please input [y/n] to continue.";;
-	esac
+    read -rp "Does the output look good? [y/n]" yn
+    case $yn in
+	[Yy]* ) echo "Good! Continuing."; break;;
+	[Nn]* ) echo "Remember to manually run the clean script and remove the out directory"; exit 1 ;;
+	* ) echo "Please input [y/n] to continue.";;
+    esac
 done
+# Remove results of test
 
+cd "${test_dir%/}/../scripts"
+./clean -f
+rm -rf out
 
 echo "----Testing complete.----"

--- a/test/test-utilities.sh
+++ b/test/test-utilities.sh
@@ -56,10 +56,10 @@ cp ../test/viz_example_test.py .
 python3 viz_example_test.py
 rm viz_example_test.py
 
-# Create a gif of the PNGs if we have imagemagick
-if command -v convert >/dev/null 2>&1 ; then
-    "${test_dir%/}/../scripts/visualization/png_to_gif.sh" out/ALTI_cone.gif out/*image.png
-fi
+# # Create a gif of the PNGs if we have imagemagick
+# if command -v convert >/dev/null 2>&1 ; then
+#     "${test_dir%/}/../scripts/visualization/png_to_gif.sh" out/ALTI_cone.gif out/*image.png
+# fi
 
 # Portably look for image viewing program, using system default application when possible
 if command -v xdg-open > /dev/null 2>&1 ; then

--- a/test/test-utilities.sh
+++ b/test/test-utilities.sh
@@ -87,10 +87,5 @@ while true; do
 	* ) echo "Please input [y/n] to continue.";;
     esac
 done
-# Remove results of test
-
-cd "${test_dir%/}/../scripts"
-./clean -f
-rm -rf out
 
 echo "----Testing complete.----"

--- a/test/viz_example_test.py
+++ b/test/viz_example_test.py
@@ -1,0 +1,20 @@
+__author__="Kelly Kochanski"
+__date__="Sept 27 2019"
+__doc__="Test script for Rescal-snow python utilities. Called by test.sh."
+
+
+import sys
+import os
+
+sys.path.append('utilities')
+import heightmap
+import cellspace # import these to check quickly for syntax errors
+import datarun
+
+filenames = ['out/'+f for f in os.listdir('out') if f[:4]=='ALTI']
+filenames = [f for f in filenames if f[-4:] == '.log']
+filenames.sort()
+
+for name in filenames:
+    hm = heightmap.HeightMap(name)
+    hm.save_color_map(name[:-4] + '_image.png')


### PR DESCRIPTION
This PR addresses a few things:

1. Concerning #41, I have made the shell scripts a little more robust. A recent commit broke `./tests/test-utilities.sh` by deleting a python file, so I added it back. I made the scripts so that they can be run from any directory, and added more robust error checking and handling.
2. I added a script to create GIFs using imagemagick. You can use them to generate new gifs for the documentation and readme, if you like, to get rid of the gifs with the watermarks.
3. Added a `requirements.txt` for old-school pip and venv users and a `Pipfile` and `Pipfile.lock` for those using `pipenv`. This resolves #44.
4. On a cluster I hit an issue building rescal-snow and finding the correct libpng and zlib libraries. The best way to handle this is usually to set `<package_name>_ROOT` in your environment to point to the version you wish to use. But this behavior requires CMake policy cmp0074 to be set to new. I tweaked CMake to accept newer/saner defaults for policies in general and explicitly set CMP0074 to NEW so that I could link against libpng provided through an easybuild LMOD module.

If you want to keep only `requirements.txt` OR both the `Pipfile` and `Pipfile.lock` (instead of requirements.txt) I'm fine with that. But I think it would be good to include one method for fixing the environment.